### PR TITLE
Drop libusb module

### DIFF
--- a/org.syntalos.syntalos.yaml
+++ b/org.syntalos.syntalos.yaml
@@ -122,7 +122,6 @@ modules:
         url: https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.bz2
         sha256: b4c198460eba6f28d34894e3a5710998818515104d6e74e5cc331ce31e46e626
 
-  - shared-modules/libusb/libusb.json
   - modules/usbutils.yaml
   - modules/ffmpeg.yaml
 


### PR DESCRIPTION
Remove libusb since it's included in the runtime version 6.10

Fixes https://github.com/flathub/org.syntalos.syntalos/issues/12